### PR TITLE
Implement CLI recursion and generator fallback

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,61 @@
+"""Command line interface for gd2doc."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import click
+
+from . import parser, generator
+
+
+def _collect_gd_files(root: Path, recursive: bool) -> List[Path]:
+    """Return a list of ``.gd`` files found under ``root``."""
+    if root.is_file() and root.suffix == ".gd":
+        return [root]
+
+    if not root.is_dir():
+        return []
+
+    pattern = "**/*.gd" if recursive else "*.gd"
+    return [p for p in root.glob(pattern)]
+
+
+@click.command()
+@click.argument("source", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--output-dir",
+    "-o",
+    type=click.Path(file_okay=False, path_type=Path),
+    required=True,
+    help="Directory to write the generated Markdown files to.",
+)
+@click.option(
+    "--recursive/--no-recursive",
+    "-r",
+    default=False,
+    help="Search SOURCE recursively for .gd files.",
+)
+def main(source: Path, output_dir: Path, recursive: bool) -> None:
+    """Generate documentation for all ``.gd`` files under ``SOURCE``."""
+
+    gd_files = _collect_gd_files(source, recursive)
+    if not gd_files:
+        click.echo("No .gd files found.")
+        return
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    base = source if source.is_dir() else source.parent
+    for gd_file in gd_files:
+        data = parser.parse_gdscript(str(gd_file))
+        rel = gd_file.relative_to(base)
+        target = (output_dir / rel).with_suffix(".md")
+        generator.generate_markdown(data, str(target))
+        click.echo(f"Generated {target.relative_to(output_dir)}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()
+

--- a/src/generator.py
+++ b/src/generator.py
@@ -1,0 +1,57 @@
+"""Markdown documentation generator using Jinja2 templates."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+try:
+    from jinja2 import Environment, FileSystemLoader
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    Environment = None  # type: ignore
+    FileSystemLoader = None  # type: ignore
+
+
+def generate_markdown(
+    data: Dict[str, Any], output_path: str, template_dir: Optional[str] = None
+) -> str:
+    """Generate a Markdown file from parsed GDScript data.
+
+    Parameters
+    ----------
+    data:
+        Parsed representation of a GDScript file as returned by ``parser.parse_gdscript``.
+    output_path:
+        Target path where the rendered Markdown file should be written.
+    template_dir:
+        Optional directory containing the ``doc.md.j2`` template.  If not
+        supplied the ``templates`` directory next to this file is used.
+
+    Returns
+    -------
+    str
+        The rendered Markdown content.
+    """
+
+    if Environment is None:
+        # Minimal fallback when Jinja2 is unavailable
+        script = data.get("script", {})
+        markdown = f"# {script.get('name', '')}\n"
+    else:
+        tdir = template_dir or os.path.join(os.path.dirname(__file__), "templates")
+        env = Environment(
+            loader=FileSystemLoader(tdir),
+            autoescape=False,
+            trim_blocks=True,
+            lstrip_blocks=True,
+        )
+        template = env.get_template("doc.md.j2")
+        markdown = template.render(**data)
+
+    output_file = Path(output_path)
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(markdown, encoding="utf-8")
+
+    return markdown
+

--- a/tests/data/sub/nested.gd
+++ b/tests/data/sub/nested.gd
@@ -1,0 +1,6 @@
+# Nested script
+extends Node
+
+func hello():
+    pass
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import sys
+from click.testing import CliRunner
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.cli import main
+
+
+def test_cli_recursive_option(tmp_path):
+    source = tmp_path / "src"
+    output = tmp_path / "out"
+    sub = source / "sub"
+    sub.mkdir(parents=True)
+
+    data_file = Path(__file__).parent / "data" / "basic.gd"
+    nested_file = Path(__file__).parent / "data" / "sub" / "nested.gd"
+    (source / "basic.gd").write_text(data_file.read_text(), encoding="utf-8")
+    (sub / "nested.gd").write_text(nested_file.read_text(), encoding="utf-8")
+
+    runner = CliRunner()
+    # without recursion only top level file should be processed
+    result = runner.invoke(main, [str(source), "-o", str(output)])
+    assert result.exit_code == 0
+    assert (output / "basic.md").exists()
+    assert not (output / "sub" / "nested.md").exists()
+
+    output2 = tmp_path / "out_rec"
+    result = runner.invoke(main, [str(source), "-o", str(output2), "--recursive"])
+    assert result.exit_code == 0
+    assert (output2 / "basic.md").exists()
+    assert (output2 / "sub" / "nested.md").exists()
+

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src import generator, parser
+
+
+def test_generate_markdown(tmp_path):
+    gd_path = Path(__file__).parent / "data" / "basic.gd"
+    parsed = parser.parse_gdscript(str(gd_path))
+
+    output = tmp_path / "basic.md"
+    generator.generate_markdown(parsed, str(output))
+
+    assert output.exists()
+    content = output.read_text(encoding="utf-8")
+    assert "# basic" in content
+


### PR DESCRIPTION
## Summary
- add optional recursive search to CLI and mirror directory structure in output
- implement fallback Markdown generation when jinja2 is unavailable
- add tests for CLI recursion and nested data file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852696c4e008320959f223f02a966d4