### PR TITLE
Add clean option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,69 @@
 # gd2doc
-Lightweight CLI that produces MkDocs-ready Markdown documentation from your Godot (gdscript) Project,
+
+`gd2doc` is a small command line tool that parses GDScript files and produces Markdown that can be fed directly into MkDocs.
+
+## Installation
+
+Python 3.8 or newer is required together with the libraries [click](https://palletsprojects.com/p/click/) and [Jinja2](https://jinja.palletsprojects.com/). Install them using `pip`:
+
+```bash
+pip install click jinja2
+```
+
+You can either include this repository as a submodule or copy the source code into a directory such as `tools/gd2doc`. Invoke the script from that directory, e.g. `tools/gd2doc/gd2doc`.
+
+### Using Nix
+
+If you have [Nix](https://nixos.org) installed, the dependencies are also
+available through the provided `shell.nix`.
+
+```bash
+nix-shell
+```
+
+This drops you into a shell where `click`, `Jinja2` and `pytest` are already
+available so you don't need to install anything on your local system. From that
+environment run the tool exactly as shown below.
+
+## Usage
+
+Run the tool with the ``gd2doc`` script and pass the directory or the individual ``.gd`` file. Use ``-o`` to set the destination directory for the generated Markdown files.
+
+```bash
+gd2doc <path-to-source> -o <output-directory>
+```
+
+Add `-r/--recursive` to also search subdirectories.
+
+Use `--clean` to delete the output directory before generating new files.
+
+### Example
+
+```bash
+gd2doc game/src -o docs --recursive
+```
+
+## Git pre-commit hook
+
+To automatically run `gd2doc` before each commit, create a script at `.git/hooks/pre-commit` with the following content:
+
+```bash
+#!/bin/sh
+gd2doc game/src -o docs --recursive
+```
+
+Don't forget to make the script executable:
+
+```bash
+chmod +x .git/hooks/pre-commit
+```
+
+This will keep your documentation up to date with every commit.
+
+## Tests
+
+Run the tests with `pytest`:
+
+```bash
+pytest -q
+```

--- a/gd2doc
+++ b/gd2doc
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+from src.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,5 +23,6 @@ python = "^3.8"
 click = "^8.1"
 jinja2 = "^3.1"
 
+
 [tool.poetry.dev-dependencies]
 pytest = "^7.0"

--- a/src/cli.py
+++ b/src/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import List
+import shutil
 
 import click
 
@@ -37,13 +38,21 @@ def _collect_gd_files(root: Path, recursive: bool) -> List[Path]:
     default=False,
     help="Search SOURCE recursively for .gd files.",
 )
-def main(source: Path, output_dir: Path, recursive: bool) -> None:
+@click.option(
+    "--clean/--no-clean",
+    default=False,
+    help="Delete OUTPUT_DIR before generating new documentation.",
+)
+def main(source: Path, output_dir: Path, recursive: bool, clean: bool) -> None:
     """Generate documentation for all ``.gd`` files under ``SOURCE``."""
 
     gd_files = _collect_gd_files(source, recursive)
     if not gd_files:
         click.echo("No .gd files found.")
         return
+
+    if clean and output_dir.exists():
+        shutil.rmtree(output_dir)
 
     output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,3 +31,22 @@ def test_cli_recursive_option(tmp_path):
     assert (output2 / "basic.md").exists()
     assert (output2 / "sub" / "nested.md").exists()
 
+
+def test_cli_clean_option(tmp_path):
+    source = tmp_path / "src"
+    source.mkdir()
+    output = tmp_path / "docs"
+    output.mkdir()
+
+    data_file = Path(__file__).parent / "data" / "basic.gd"
+    (source / "basic.gd").write_text(data_file.read_text(), encoding="utf-8")
+
+    leftover = output / "old.md"
+    leftover.write_text("old", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(main, [str(source), "-o", str(output), "--clean"])
+    assert result.exit_code == 0
+    assert (output / "basic.md").exists()
+    assert not leftover.exists()
+


### PR DESCRIPTION
## Summary
- add a `--clean` flag to wipe output before rendering new docs
- document the new option in the README
- test cleaning functionality

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68526fdfffb08320b3653c237e23dc58