### PR TITLE
Add index pages for all parent dirs and fix comment parsing

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -64,6 +64,8 @@ def main(source: Path, output_dir: Path, recursive: bool, clean: bool) -> None:
         generator.generate_markdown(data, str(target))
         click.echo(f"Generated {target.relative_to(output_dir)}")
 
+    generator.generate_indexes(gd_files, base, output_dir)
+
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation
     main()

--- a/src/parser.py
+++ b/src/parser.py
@@ -91,7 +91,7 @@ def parse_gdscript(path: str) -> Dict[str, Any]:
 
     # header comments
     while index < len(lines) and lines[index].strip().startswith("#"):
-        comment = lines[index].strip()[1:].strip()
+        comment = lines[index].strip().lstrip("#").strip()
         if comment.lower().startswith("todo"):
             todos.append(comment[4:].strip())
         else:
@@ -113,7 +113,7 @@ def parse_gdscript(path: str) -> Dict[str, Any]:
         stripped = line.strip()
 
         if stripped.startswith("#"):
-            text = stripped[1:].strip()
+            text = stripped.lstrip("#").strip()
             if text.lower().startswith("todo"):
                 todos.append(text[4:].strip())
             else:

--- a/tests/data/double_hash.gd
+++ b/tests/data/double_hash.gd
@@ -1,0 +1,10 @@
+## Example script
+## Another line
+## TODO: header
+extends Node
+
+## Function description
+func foo():
+    pass
+
+## TODO: bottom

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,3 +50,54 @@ def test_cli_clean_option(tmp_path):
     assert (output / "basic.md").exists()
     assert not leftover.exists()
 
+
+def test_cli_generates_indexes(tmp_path):
+    source = tmp_path / "src"
+    output = tmp_path / "out"
+    sub = source / "sub"
+    sub.mkdir(parents=True)
+
+    data_file = Path(__file__).parent / "data" / "basic.gd"
+    nested_file = Path(__file__).parent / "data" / "sub" / "nested.gd"
+    (source / "basic.gd").write_text(data_file.read_text(), encoding="utf-8")
+    (sub / "nested.gd").write_text(nested_file.read_text(), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(main, [str(source), "-o", str(output), "--recursive"])
+    assert result.exit_code == 0
+
+    root_index = output / "index.md"
+    assert root_index.exists()
+    content_root = root_index.read_text(encoding="utf-8")
+    assert "basic.md" in content_root
+    assert "sub/index.md" in content_root
+
+    sub_index = output / "sub" / "index.md"
+    assert sub_index.exists()
+    content_sub = sub_index.read_text(encoding="utf-8")
+    assert "nested.md" in content_sub
+
+
+def test_cli_indexes_intermediate_dirs(tmp_path):
+    source = tmp_path / "src"
+    output = tmp_path / "out"
+    deep = source / "a" / "b"
+    deep.mkdir(parents=True)
+
+    data_file = Path(__file__).parent / "data" / "basic.gd"
+    (deep / "deep.gd").write_text(data_file.read_text(), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(main, [str(source), "-o", str(output), "-r"])
+    assert result.exit_code == 0
+
+    assert (output / "index.md").exists()
+    assert (output / "a" / "index.md").exists()
+    assert (output / "a" / "b" / "index.md").exists()
+
+    root_content = (output / "index.md").read_text(encoding="utf-8")
+    assert "a/index.md" in root_content
+    a_content = (output / "a" / "index.md").read_text(encoding="utf-8")
+    assert "b/index.md" in a_content
+    b_content = (output / "a" / "b" / "index.md").read_text(encoding="utf-8")
+    assert "deep.md" in b_content

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -98,3 +98,18 @@ def test_parse_advanced():
         ": constant to check",
         ": final todo",
     ]
+
+def test_parse_double_hash_comments():
+    gd_path = Path(__file__).parent / "data" / "double_hash.gd"
+    result = parser.parse_gdscript(str(gd_path))
+
+    script = result["script"]
+    assert script["short_description"] == "Example script"
+    assert script["description"] == "Example script\nAnother line"
+
+    assert len(result["functions"]) == 1
+    func = result["functions"][0]
+    assert func["name"] == "foo"
+    assert func["description"] == "Function description"
+
+    assert result["todos"] == [": header", ": bottom"]


### PR DESCRIPTION
## Summary
- index generation now includes intermediate folders
- parse comments starting with multiple `#`
- tests cover nested indexes and double-`#` comments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68527e42eb8c8320b057852f3df7df90