### PR TITLE
Add mkdocs.yml generation

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 import shutil
 
 import click
@@ -43,7 +43,19 @@ def _collect_gd_files(root: Path, recursive: bool) -> List[Path]:
     default=False,
     help="Delete OUTPUT_DIR before generating new documentation.",
 )
-def main(source: Path, output_dir: Path, recursive: bool, clean: bool) -> None:
+@click.option(
+    "--project-root",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Root directory for mkdocs.yml. Defaults to parent of OUTPUT_DIR.",
+)
+def main(
+    source: Path,
+    output_dir: Path,
+    recursive: bool,
+    clean: bool,
+    project_root: Optional[Path],
+) -> None:
     """Generate documentation for all ``.gd`` files under ``SOURCE``."""
 
     gd_files = _collect_gd_files(source, recursive)
@@ -65,6 +77,9 @@ def main(source: Path, output_dir: Path, recursive: bool, clean: bool) -> None:
         click.echo(f"Generated {target.relative_to(output_dir)}")
 
     generator.generate_indexes(gd_files, base, output_dir)
+
+    root_dir = project_root or Path.cwd()
+    generator.generate_mkdocs_yml(root_dir, output_dir)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -101,3 +101,22 @@ def test_cli_indexes_intermediate_dirs(tmp_path):
     assert "b/index.md" in a_content
     b_content = (output / "a" / "b" / "index.md").read_text(encoding="utf-8")
     assert "deep.md" in b_content
+
+
+def test_cli_creates_mkdocs(tmp_path):
+    source = tmp_path / "src"
+    source.mkdir()
+    output = tmp_path / "docs"
+
+    data_file = Path(__file__).parent / "data" / "basic.gd"
+    (source / "basic.gd").write_text(data_file.read_text(), encoding="utf-8")
+
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(main, [str(source), "-o", str(output)])
+        assert result.exit_code == 0
+
+        mkdocs_file = Path("mkdocs.yml")
+        assert mkdocs_file.exists()
+        content = mkdocs_file.read_text(encoding="utf-8")
+        assert "Codebase" in content


### PR DESCRIPTION
## Summary
- generate mkdocs configuration during CLI run
- support `--project-root` option
- create mkdocs.yml using docs output
- test mkdocs generation
- default project root to execution directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685285db5928832091544dfefbd10b74